### PR TITLE
ignore final keyword for classes in JsTranslator #9

### DIFF
--- a/src/Viewi/JsTranslator.php
+++ b/src/Viewi/JsTranslator.php
@@ -717,6 +717,10 @@ class JsTranslator
                             $this->putIndentation = true;
                             break;
                         }
+                    case 'final': {
+                        $this->position += strlen($this->lastBreak);
+                        break;
+                    }
                     case '[': {
                             $code .= $this->readArray(']') . ' '; // TODO: improve white spacing
                             if ($this->skipVariableKey) {

--- a/src/Viewi/JsTranslator.php
+++ b/src/Viewi/JsTranslator.php
@@ -718,7 +718,7 @@ class JsTranslator
                             break;
                         }
                     case 'final': {
-                        $this->position += strlen($this->lastBreak);
+                        $skipLastSaving = true;
                         break;
                     }
                     case '[': {


### PR DESCRIPTION
Fixes #9 
The final keyword is not supported in JavaScript and creates a runtime error on the browser. As php still executes the classes on SSR the runtime error when extending a final class should still be triggered there so the final keyword is still valid and behaves as expected