### PR TITLE
chore(gitignore): add OS and editor metadata entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,21 @@ composer.lock
 **/vendor/**
 src/v1/**
 /.idea
+# OS metadata
+.DS_Store
+._*
+.Spotlight-V100
+.Trashes
+.AppleDouble
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+Desktop.ini
+$RECYCLE.BIN/
+*.lnk
+
+# Editor / IDE
+.idea/
+.vscode/
+*.swp
+*.swo


### PR DESCRIPTION
Small `.gitignore` cleanup: adds standard OS metadata files (`.DS_Store`, `Thumbs.db`, `Desktop.ini`) and editor project folders (`.idea/`, `.vscode/`) that aren't currently listed.

No effect on tracked files â€” this only prevents new accidental commits.